### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ EXAMPLE
 ```hcl
 module "dcos-elb-public-agents" {
   source  = "terraform-dcos/elb-public-agents/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "production"
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@
  *```hcl
  * module "dcos-elb-public-agents" {
  *   source  = "terraform-dcos/elb-public-agents/aws"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   cluster_name = "production"
  *
@@ -28,7 +28,7 @@ provider "aws" {}
 
 module "public-agents" {
   source  = "dcos-terraform/elb/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2